### PR TITLE
Fix multiple bugs and inconsistencies in customer management

### DIFF
--- a/app/Filament/Resources/CustomerResource.php
+++ b/app/Filament/Resources/CustomerResource.php
@@ -75,11 +75,11 @@ class CustomerResource extends Resource
                         Forms\Components\TextInput::make('membership_number')
                             ->label('Número de Afiliación')
                             ->maxLength(255)
-                            ->default(fn ($record) => $record->membership->membership_number ?? ''),
+                            ->default(fn ($record) => $record?->membership?->membership_number ?? ''),
 
                         Forms\Components\DatePicker::make('membership_date')
                             ->label('Fecha de Afiliación')
-                            ->default(fn ($record) => $record->membership->membership_date ?? null),
+                            ->default(fn ($record) => $record?->membership?->membership_date ?? null),
 
                         Forms\Components\Select::make('membership_status')
                             ->label('Estado de Afiliación')
@@ -87,12 +87,12 @@ class CustomerResource extends Resource
                                 'active' => 'Activo',
                                 'inactive' => 'Inactivo',
                             ])
-                            ->default(fn ($record) => $record->membership->membership_status ?? ''),
+                            ->default(fn ($record) => $record?->membership?->membership_status ?? ''),
 
                         Forms\Components\Textarea::make('wish')
                             ->label('Deseo')
                             ->maxLength(65535)
-                            ->default(fn ($record) => $record->membership->wish ?? ''),
+                            ->default(fn ($record) => $record?->membership?->wish ?? ''),
                     ])
                     ->columns(2)
                     ->relationship('membership'),

--- a/app/Filament/Resources/MembershipResource.php
+++ b/app/Filament/Resources/MembershipResource.php
@@ -29,7 +29,7 @@ class MembershipResource extends Resource
             ->schema([
                 Forms\Components\TextInput::make('membership_number')
                     ->label('Número de Afiliación')
-                    ->required()
+                    ->nullable()
                     ->maxLength(255),
                 
                 Forms\Components\DatePicker::make('membership_date')
@@ -73,9 +73,6 @@ class MembershipResource extends Resource
                 Tables\Columns\TextColumn::make('membership_date')
                     ->label('Fecha de Afiliación')
                     ->date(),
-
-                Tables\Columns\TextColumn::make('membership_status')
-                    ->label('Estado'),
 
                 Tables\Columns\TextColumn::make('membership_status')
                     ->label('Estado')

--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -30,18 +30,24 @@ class CustomerController extends Controller
 
     public function store(CustomerStoreRequest $request): RedirectResponse
     {
-        DB::transaction(function () use ($request) {
-            $customer = Customer::create($request->validated());
+        try {
+            DB::transaction(function () use ($request) {
+                $customer = Customer::create($request->validated());
 
-            // Crear contactos si existen
-            if ($request->has('contacts')) {
-                foreach ($request->contacts as $contactData) {
-                    $customer->contacts()->create($contactData);
+                // Crear contactos si existen
+                if ($request->has('contacts')) {
+                    foreach ($request->contacts as $contactData) {
+                        $customer->contacts()->create($contactData);
+                    }
                 }
-            }
-        });
+            });
 
-        return redirect()->route('customers.index')->with('success', 'Cliente creado con éxito.');
+            return redirect()->route('customers.index')->with('success', 'Cliente creado con éxito.');
+        } catch (\Exception $e) {
+            return redirect()->back()
+                ->withInput()
+                ->withErrors(['error' => 'Error al crear el cliente: ' . $e->getMessage()]);
+        }
     }
 
     public function show(Request $request, Customer $customer): View
@@ -58,35 +64,41 @@ class CustomerController extends Controller
 
     public function update(CustomerUpdateRequest $request, Customer $customer): RedirectResponse
     {
-        DB::transaction(function () use ($request, $customer) {
-            $customer->update($request->validated());
+        try {
+            DB::transaction(function () use ($request, $customer) {
+                $customer->update($request->validated());
 
-            // Obtener los IDs de los contactos actuales
-            $currentContactIds = $customer->contacts()->pluck('id')->toArray();
+                // Obtener los IDs de los contactos actuales
+                $currentContactIds = $customer->contacts()->pluck('id')->toArray();
 
-            // IDs de los contactos recibidos en la solicitud
-            $receivedContactIds = array_filter(array_column($request->contacts, 'id'));
+                // IDs de los contactos recibidos en la solicitud
+                $receivedContactIds = array_filter(array_column($request->contacts, 'id'));
 
-            // Eliminar contactos que ya no existen
-            $contactsToDelete = array_diff($currentContactIds, $receivedContactIds);
-            Contact::destroy($contactsToDelete);
+                // Eliminar contactos que ya no existen
+                $contactsToDelete = array_diff($currentContactIds, $receivedContactIds);
+                Contact::destroy($contactsToDelete);
 
-            // Crear o actualizar contactos
-            foreach ($request->contacts as $contactData) {
-                if (isset($contactData['id'])) {
-                    // Actualizar contacto existente
-                    $contact = Contact::find($contactData['id']);
-                    if ($contact) {
-                        $contact->update($contactData);
+                // Crear o actualizar contactos
+                foreach ($request->contacts as $contactData) {
+                    if (isset($contactData['id'])) {
+                        // Actualizar contacto existente
+                        $contact = $customer->contacts()->find($contactData['id']);
+                        if ($contact) {
+                            $contact->update($contactData);
+                        }
+                    } else {
+                        // Crear nuevo contacto
+                        $customer->contacts()->create($contactData);
                     }
-                } else {
-                    // Crear nuevo contacto
-                    $customer->contacts()->create($contactData);
                 }
-            }
-        });
+            });
 
-        return redirect()->route('customers.index')->with('success', 'Cliente actualizado con éxito.');
+            return redirect()->route('customers.index')->with('success', 'Cliente actualizado con éxito.');
+        } catch (\Exception $e) {
+            return redirect()->back()
+                ->withInput()
+                ->withErrors(['error' => 'Error al actualizar el cliente: ' . $e->getMessage()]);
+        }
     }
 
     public function destroy(Request $request, Customer $customer): RedirectResponse

--- a/app/Http/Requests/CustomerStoreRequest.php
+++ b/app/Http/Requests/CustomerStoreRequest.php
@@ -24,7 +24,7 @@ class CustomerStoreRequest extends FormRequest
             'nationality' => ['nullable', 'string', 'max:100'],
             'residence_place' => ['nullable', 'string', 'max:255'],
             'postal_code' => ['nullable', 'string', 'max:20'],
-            'approx_enrollment' => ['nullable', 'date'],
+            'cencus' => ['nullable', 'string'],
             'marital_status' => ['nullable', 'string', 'max:50'],
             'family' => ['nullable', 'string'],
             'document_number' => ['required', 'string', 'max:50'],

--- a/app/Http/Requests/CustomerUpdateRequest.php
+++ b/app/Http/Requests/CustomerUpdateRequest.php
@@ -24,7 +24,7 @@ class CustomerUpdateRequest extends FormRequest
             'nationality' => ['nullable', 'string', 'max:100'],
             'residence_place' => ['nullable', 'string', 'max:255'],
             'postal_code' => ['nullable', 'string', 'max:20'],
-            'approx_enrollment' => ['nullable', 'date'],
+            'cencus' => ['nullable', 'string'],
             'marital_status' => ['nullable', 'string', 'max:50'],
             'family' => ['nullable', 'string'],
             'document_number' => ['required', 'string', 'max:50'],

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -16,7 +16,7 @@ use Parallax\FilamentComments\Models\Traits\HasFilamentComments;
  * @property string $nationality
  * @property string $residence_place
  * @property string $postal_code
- * @property \Carbon\Carbon $approx_enrollment
+ * @property string $cencus
  * @property string $marital_status
  * @property string $family
  * @property string $document_number


### PR DESCRIPTION
## Summary
This PR fixes several bugs and inconsistencies found during code analysis:

- Fixed duplicate column definition in MembershipResource
- Standardized field naming across the application
- Added null-safe operators to prevent runtime errors
- Improved form validation consistency
- Added proper error handling for database operations
- Enhanced security with ownership validation

## Bug Fixes

### 1. ✅ Duplicate Column in MembershipResource
- **Issue**: Duplicate `membership_status` column definition causing UI issues
- **Fix**: Removed the first duplicate column definition

### 2. ✅ Field Mismatch in Customer Model  
- **Issue**: Migration uses `cencus` but PHPDoc/validation uses `approx_enrollment`
- **Fix**: Updated PHPDoc and validation rules to use `cencus` to match migration

### 3. ⏭️ Unique Constraint Validation
- **Skipped**: Per user request, unique constraint validation is not required anymore

### 4. ✅ Membership Field Access Without Null Check
- **Issue**: Accessing membership properties without null checking could cause errors
- **Fix**: Added null-safe operators (?->) to prevent null pointer exceptions

### 5. ✅ MembershipResource Validation Inconsistency
- **Issue**: Form requires `membership_number` but DB allows nullable
- **Fix**: Changed form field from required() to nullable() to match DB schema

### 6. ✅ Transaction Error Handling
- **Issue**: DB transactions don't have explicit error handling
- **Fix**: Added try-catch blocks around transactions with proper error messages

### 7. ✅ Contact Ownership Validation
- **Issue**: Contact update doesn't validate ownership
- **Fix**: Changed Contact::find() to $customer->contacts()->find() to ensure ownership

## Test Plan
- [ ] Test customer creation with and without contacts
- [ ] Test customer update operations
- [ ] Verify membership fields handle null values correctly
- [ ] Test error handling by triggering database errors
- [ ] Verify contact updates only work for owned contacts

🤖 Generated with [Claude Code](https://claude.ai/code)