### PR TITLE
fix: resolve Filament closure parameter binding error in CustomerResource

### DIFF
--- a/app/Filament/Resources/CustomerResource.php
+++ b/app/Filament/Resources/CustomerResource.php
@@ -56,7 +56,7 @@ class CustomerResource extends Resource
                     ->relationship('documentType', 'name')
                     ->required()
                     ->reactive()
-                    ->afterStateUpdated(fn ($_, callable $set) => $set('document_number', null)),
+                    ->afterStateUpdated(fn (callable $set) => $set('document_number', null)),
 
                 Forms\Components\TextInput::make('document_number')
                     ->label('Número de Documento')


### PR DESCRIPTION
## Summary
Fixes critical production bug preventing customer creation with error:
```
Illuminate\Contracts\Container\BindingResolutionException
An attempt was made to evaluate a closure for [Filament\Forms\Components\Select], 
but [$_] was unresolvable.
```

## Root Cause
The `afterStateUpdated` closure in the document type selector was using an unused parameter `$_` which Filament's dependency injection container couldn't resolve.

## Changes

### Before:
```php
->afterStateUpdated(fn ($_, callable $set) => $set('document_number', null))
```

### After:
```php
->afterStateUpdated(fn (callable $set) => $set('document_number', null))
```

## Impact
- ✅ Customers can now be created successfully
- ✅ Document number field clears when document type changes (reactive behavior maintained)
- ✅ No breaking changes to existing functionality

## Test Plan
- [x] Laravel Pint code style checks pass
- [x] PHPStan level 5 static analysis passes with no errors
- [x] Pre-commit hooks executed successfully
- [ ] Manual test: Create new customer
- [ ] Manual test: Change document type and verify document number clears

## Related Issues
Reported in production - customer creation was completely broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)